### PR TITLE
Fix/resolution

### DIFF
--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -112,7 +112,7 @@ class BaseDIDResolver(ABC):
 
         py_did = DID(did) if isinstance(did, str) else did
 
-        if not await self.supports(profile, py_did.method):
+        if not await self.supports(profile, py_did):
             raise DIDMethodNotSupported(
                 f"{self.__class__.__name__} does not support DID method {py_did.method}"
             )

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -44,6 +44,7 @@ class DIDResolver:
                 resolution: ResolutionResult = await resolver.resolve(
                     profile,
                     py_did,
+                    retrieve_metadata
                 )
                 if resolution.metadata:
                     LOGGER.debug(

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -53,7 +53,7 @@ class DIDResolver:
                         resolution.metadata._asdict(),
                     )
                 return resolution
-            except DIDNotFound:
+            except (DIDNotFound, DIDMethodNotSupported):
                 LOGGER.debug("DID %s not found by resolver %s", did, resolver)
 
         raise DIDNotFound(f"DID {did} could not be resolved")

--- a/aries_cloudagent/resolver/tests/test_base.py
+++ b/aries_cloudagent/resolver/tests/test_base.py
@@ -1,6 +1,7 @@
 """Test Base DID Resolver methods."""
 
 from typing import Union
+from unittest.mock import MagicMock
 
 import pytest
 from pydid import DID, DIDDocument
@@ -50,7 +51,8 @@ def test_native_on_non_native(non_native_resolver):
 
 
 @pytest.mark.asyncio
-async def test_supports(profile: Profile, native_resolver):
+async def test_supports(native_resolver):
+    profile = MagicMock()
     assert await native_resolver.supports(profile, "did:test:123") is True
     assert await native_resolver.supports(profile, "not supported") is False
 

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -107,29 +107,35 @@ def test_create_resolver(resolver):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("did, method", zip(TEST_DIDS, TEST_DID_METHODS))
 async def test_match_did_to_resolver(profile, resolver, did, method):
-    base_resolver, *_ = resolver._match_did_to_resolver(DID(did))
+    base_resolver, *_ = await resolver._match_did_to_resolver(profile, DID(did))
     assert await base_resolver.supports(profile, did)
 
 
-def test_match_did_to_resolver_x_not_supported(resolver):
+@pytest.mark.asyncio
+async def test_match_did_to_resolver_x_not_supported(profile, resolver):
+    # TODO: FIX
     py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
     with pytest.raises(DIDMethodNotSupported):
-        resolver._match_did_to_resolver(py_did)
+        await resolver._match_did_to_resolver(profile, py_did)
 
 
-def test_match_did_to_resolver_native_priority(profile):
+@pytest.mark.asyncio
+async def test_match_did_to_resolver_native_priority(profile):
     registry = DIDResolverRegistry()
     native = MockResolver(["sov"], native=True)
     non_native = MockResolver(["sov"], native=False)
     registry.register(non_native)
     registry.register(native)
     resolver = DIDResolver(registry)
-    assert [native, non_native] == resolver._match_did_to_resolver(
+
+    result = await resolver._match_did_to_resolver(
         profile, DID(TEST_DID0)
     )
+    assert [native, non_native] == result
 
 
-def test_match_did_to_resolver_registration_order(profile):
+@pytest.mark.asyncio
+async def test_match_did_to_resolver_registration_order(profile):
     registry = DIDResolverRegistry()
     native1 = MockResolver(["sov"], native=True)
     registry.register(native1)
@@ -140,7 +146,7 @@ def test_match_did_to_resolver_registration_order(profile):
     native4 = MockResolver(["sov"], native=True)
     registry.register(native4)
     resolver = DIDResolver(registry)
-    assert [native1, native2, native4, non_native3] == resolver._match_did_to_resolver(
+    assert [native1, native2, native4, non_native3] == await resolver._match_did_to_resolver(
         profile, DID(TEST_DID0)
     )
 
@@ -177,7 +183,7 @@ async def test_resolve_did(resolver, profile, did):
 @pytest.mark.asyncio
 async def test_resolve_did_x_not_supported(resolver, profile):
     py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
-    with pytest.raises(DIDMethodNotSupported):
+    with pytest.raises(DIDNotFound):
         await resolver.resolve(profile, py_did)
 
 


### PR DESCRIPTION
Some fixes detected in the didcomm integration tests
Remaining tests:

- [ ] FAILED aries_cloudagent/resolver/tests/test_did_resolver.py::test_match_did_to_resolver[did:sov:Kkyqu7CJFuQSvBp468uaDe-sov] - TypeError: 'coroutine' object is not iterable
- [ ] FAILED aries_cloudagent/resolver/tests/test_did_resolver.py::test_match_did_to_resolver[did:btcr:8kyt-fzzq-qpqq-ljsc-5l-btcr] - TypeError: 'coroutine' object is not iter...
- [ ] FAILED aries_cloudagent/resolver/tests/test_did_resolver.py::test_match_did_to_resolver[did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a-ethr] - TypeError: 'c...
- [ ] FAILED aries_cloudagent/resolver/tests/test_did_resolver.py::test_match_did_to_resolver[did:ion:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A-ion] - TypeError: 'corouti...
- [ ] FAILED aries_cloudagent/resolver/tests/test_did_resolver.py::test_match_did_to_resolver[did:github:ghdid-github] - TypeError: 'coroutine' object is not iterable
- [ ] FAILED aries_cloudagent/resolver/tests/test_did_resolver.py::test_match_did_to_resolver_x_not_supported - Failed: DID NOT RAISE <class 'aries_cloudagent.resolver.base.DI...

